### PR TITLE
Fix repeated metadata parsing

### DIFF
--- a/src/app/decode/page.tsx
+++ b/src/app/decode/page.tsx
@@ -47,7 +47,7 @@ export default function DecodePage() {
             };
             extractExif();
         }
-    }, [appContext]);
+    }, [appContext?.uploadedFile, appContext?.exifData]);
 
     if (!appContext || !appContext.uploadedFile) {
         return (


### PR DESCRIPTION
## Summary
- prevent repeated `useEffect` invocation when app context updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843671c755c8333a8c38482137b0385