### PR TITLE
feat: add metadata extraction util and responsive output

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1392,54 +1392,63 @@ html[data-theme="light"] .icon-item-wrapper:not(.placeholder):hover .exif-detail
 
 .decode-page-container {
     width: 100%;
-    flex-grow: 1; 
-    display: flex;
-    flex-direction: row; 
-    justify-content: center; 
-    align-items: center; 
-    gap: 24px; 
-    flex-wrap: wrap; 
-  }
-  
-  .metadata-card {
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
-    width: 500px; 
-    height: 658px; 
-    max-width: 90%;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+}
+
+@media (min-width: 768px) {
+    .decode-page-container {
+        flex-direction: row;
+    }
+}
+
+.metadata-card {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 500px;
+    max-height: 80vh;
     border-radius: 20px;
     padding: 20px;
     gap: 12px;
     overflow: hidden;
-  }
-  
-  html[data-theme="light"] .metadata-card {
+}
+
+@media (min-width: 768px) {
+    .metadata-card {
+        height: 658px;
+    }
+}
+
+html[data-theme="light"] .metadata-card {
     background-color: var(--backgroundColor-gray-lightest);
-  }
-  html[data-theme="dark"] .metadata-card {
+}
+
+html[data-theme="dark"] .metadata-card {
     background-color: var(--backgroundColor-gray-dark-15);
-  }
-  
-  .metadata-card h1 {
+}
+
+.metadata-card h1 {
     margin: 0;
     padding: 0;
     text-align: center;
-  }
-  
-  /* CHANGE THIS WRAPPER */
-  .metadata-content-wrapper {
+}
+
+.metadata-content-wrapper {
     width: 100%;
     height: 100%;
-    overflow: auto; /* This enables both vertical and horizontal scrolling */
+    overflow: auto;
     line-height: 1.6;
-  }
-  
-  /* REMOVE THIS CLASS as it is no longer needed */
-  /* .metadata-code-block {
+}
+
+.metadata-content-wrapper pre {
     white-space: pre-wrap;
-    word-break: break-all;
+    word-break: break-word;
+    margin: 0;
     font-family: var(--font-geist-mono);
     font-size: 0.9em;
-    line-height: 1.6;
-  } 
-  */
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,36 @@
+import { parseMetadata } from "@uswriting/exiftool";
+
+export interface MetadataResult {
+  success: boolean;
+  metadata: Record<string, unknown> | null;
+  error?: string;
+}
+
+export async function extractMetadata(file: File): Promise<MetadataResult> {
+  try {
+    const result = await parseMetadata(file, {
+      args: ["-json", "-n"],
+      transform: (data) => JSON.parse(data),
+    });
+
+    if (
+      result.success &&
+      Array.isArray(result.data) &&
+      result.data.length > 0
+    ) {
+      return { success: true, metadata: result.data[0] };
+    }
+
+    return {
+      success: false,
+      metadata: null,
+      error: result.error || "Failed to parse metadata.",
+    };
+  } catch (err) {
+    return {
+      success: false,
+      metadata: null,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add `extractMetadata` helper wrapping exiftool and returning {success, metadata, error}
- support WebP uploads and streamline metadata decode flow
- style metadata output responsively for mobile and desktop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8167fe788333908ef2bd5a1b6917