### PR TITLE
feat: add tile metadata view toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1438,6 +1438,32 @@ html[data-theme="dark"] .metadata-card {
     text-align: center;
 }
 
+.metadata-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.view-toggle-button {
+    font-size: 0.8rem;
+    padding: 4px 8px;
+    border-radius: 6px;
+    border: 1px solid;
+    cursor: pointer;
+    background-color: var(--backgroundColor-gray-light);
+    color: var(--backgroundColor-gray-dark-17);
+}
+
+html[data-theme="dark"] .view-toggle-button {
+    background-color: var(--backgroundColor-gray-dark-13);
+    color: var(--backgroundColor-gray-lightest);
+    border-color: var(--backgroundColor-gray-dark-9);
+}
+
+html[data-theme="light"] .view-toggle-button {
+    border-color: var(--backgroundColor-gray-dark);
+}
+
 .metadata-content-wrapper {
     width: 100%;
     height: 100%;
@@ -1451,4 +1477,39 @@ html[data-theme="dark"] .metadata-card {
     margin: 0;
     font-family: var(--font-geist-mono);
     font-size: 0.9em;
+}
+
+.metadata-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+}
+
+.metadata-tile {
+    padding: 10px;
+    border-radius: 8px;
+    border: 1px solid;
+    word-break: break-word;
+}
+
+html[data-theme="light"] .metadata-tile {
+    background-color: var(--backgroundColor-gray-light);
+    border-color: var(--backgroundColor-gray);
+    color: var(--backgroundColor-gray-dark-17);
+}
+
+html[data-theme="dark"] .metadata-tile {
+    background-color: var(--backgroundColor-gray-dark-13);
+    border-color: var(--backgroundColor-gray-dark-9);
+    color: var(--backgroundColor-gray-lightest);
+}
+
+.metadata-tile-key {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 4px;
+}
+
+.metadata-tile-value {
+    font-size: 0.85em;
 }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -173,6 +173,7 @@ export default function UploadPage() {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [showMetadata, setShowMetadata] = useState(false);
   const [isDecoding, setIsDecoding] = useState(false);
+  const [isGridView, setIsGridView] = useState(false);
 
   const router = useRouter();
   const appContext = useContext(AppContext);
@@ -210,6 +211,7 @@ export default function UploadPage() {
       setUploadedFile(file);
       setShowMetadata(false);
       setIsDecoding(false);
+      setIsGridView(false);
       const reader = new FileReader();
       reader.onload = (e) => {
         setImagePreviewUrl(e.target?.result as string);
@@ -281,6 +283,7 @@ export default function UploadPage() {
     setExifData(null);
     setShowMetadata(false);
     setIsDecoding(false);
+    setIsGridView(false);
   };
 
   const renderExifData = () => {
@@ -308,6 +311,23 @@ export default function UploadPage() {
         return { key: formattedKey, value };
       },
     );
+
+    if (isGridView) {
+      return (
+        <div className="metadata-grid">
+          {formattedEntries.map(({ key, value }) => {
+            const valueStr =
+              typeof value === "object" ? JSON.stringify(value) : String(value);
+            return (
+              <div key={key} className="metadata-tile">
+                <span className="metadata-tile-key">{key}</span>
+                <span className="metadata-tile-value">{valueStr}</span>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
 
     const maxKeyLength = Math.max(
       ...formattedEntries.map((item) => item.key.length),
@@ -425,9 +445,18 @@ export default function UploadPage() {
             </div>
             {showMetadata && (
               <div className="metadata-card">
-                <h1>
-                  <code>metadata</code>
-                </h1>
+                <div className="metadata-card-header">
+                  <h1>
+                    <code>metadata</code>
+                  </h1>
+                  <button
+                    className="view-toggle-button"
+                    onClick={() => setIsGridView((prev) => !prev)}
+                    type="button"
+                  >
+                    {isGridView ? "Text View" : "Tile View"}
+                  </button>
+                </div>
                 <div className="metadata-content-wrapper">
                   {renderExifData()}
                 </div>


### PR DESCRIPTION
## Summary
- add ability to toggle metadata between text and tile views
- render metadata in grid-based tile layout with new styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a87b6b7cc8333840758d9d0c23a33